### PR TITLE
fix: output corruption when control sequence left in buffer

### DIFF
--- a/_example/exec-command/main.go
+++ b/_example/exec-command/main.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"os/exec"
 
-	prompt "github.com/c-bata/go-prompt"
+	prompt "github.com/StepY1aoZz/go-prompt"
 )
 
 func executor(t string) {

--- a/_example/http-prompt/main.go
+++ b/_example/http-prompt/main.go
@@ -10,7 +10,7 @@ import (
 	"path"
 	"strings"
 
-	prompt "github.com/c-bata/go-prompt"
+	prompt "github.com/StepY1aoZz/go-prompt"
 )
 
 type RequestContext struct {

--- a/_example/live-prefix/main.go
+++ b/_example/live-prefix/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	prompt "github.com/c-bata/go-prompt"
+	prompt "github.com/StepY1aoZz/go-prompt"
 )
 
 var LivePrefixState struct {

--- a/_example/simple-echo/cjk-cyrillic/main.go
+++ b/_example/simple-echo/cjk-cyrillic/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	prompt "github.com/c-bata/go-prompt"
+	prompt "github.com/StepY1aoZz/go-prompt"
 )
 
 func executor(in string) {

--- a/_example/simple-echo/main.go
+++ b/_example/simple-echo/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	prompt "github.com/c-bata/go-prompt"
+	prompt "github.com/StepY1aoZz/go-prompt"
 )
 
 func completer(in prompt.Document) []prompt.Suggest {

--- a/_tools/complete_file/main.go
+++ b/_tools/complete_file/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strings"
 
-	prompt "github.com/c-bata/go-prompt"
-	"github.com/c-bata/go-prompt/completer"
+	prompt "github.com/StepY1aoZz/go-prompt"
+	"github.com/StepY1aoZz/go-prompt/completer"
 )
 
 var filePathCompleter = completer.FilePathCompleter{

--- a/_tools/vt100_debug/main.go
+++ b/_tools/vt100_debug/main.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package main
@@ -6,8 +7,8 @@ import (
 	"fmt"
 	"syscall"
 
-	prompt "github.com/c-bata/go-prompt"
-	"github.com/c-bata/go-prompt/internal/term"
+	prompt "github.com/StepY1aoZz/go-prompt"
+	"github.com/StepY1aoZz/go-prompt/internal/term"
 )
 
 func main() {

--- a/buffer.go
+++ b/buffer.go
@@ -3,7 +3,7 @@ package prompt
 import (
 	"strings"
 
-	"github.com/c-bata/go-prompt/internal/debug"
+	"github.com/StepY1aoZz/go-prompt/internal/debug"
 )
 
 // Buffer emulates the console buffer.

--- a/completer/file.go
+++ b/completer/file.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"runtime"
 
-	prompt "github.com/c-bata/go-prompt"
-	"github.com/c-bata/go-prompt/internal/debug"
+	prompt "github.com/StepY1aoZz/go-prompt"
+	"github.com/StepY1aoZz/go-prompt/internal/debug"
 )
 
 var (

--- a/completion.go
+++ b/completion.go
@@ -3,7 +3,7 @@ package prompt
 import (
 	"strings"
 
-	"github.com/c-bata/go-prompt/internal/debug"
+	"github.com/StepY1aoZz/go-prompt/internal/debug"
 	runewidth "github.com/mattn/go-runewidth"
 )
 

--- a/document.go
+++ b/document.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/c-bata/go-prompt/internal/bisect"
-	istrings "github.com/c-bata/go-prompt/internal/strings"
+	"github.com/StepY1aoZz/go-prompt/internal/bisect"
+	istrings "github.com/StepY1aoZz/go-prompt/internal/strings"
 	runewidth "github.com/mattn/go-runewidth"
 )
 

--- a/emacs.go
+++ b/emacs.go
@@ -1,6 +1,6 @@
 package prompt
 
-import "github.com/c-bata/go-prompt/internal/debug"
+import "github.com/StepY1aoZz/go-prompt/internal/debug"
 
 /*
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/c-bata/go-prompt
+module github.com/StepY1aoZz/go-prompt
 
 go 1.14
 

--- a/input_posix.go
+++ b/input_posix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package prompt
@@ -5,7 +6,7 @@ package prompt
 import (
 	"syscall"
 
-	"github.com/c-bata/go-prompt/internal/term"
+	"github.com/StepY1aoZz/go-prompt/internal/term"
 	"golang.org/x/sys/unix"
 )
 

--- a/input_test.go
+++ b/input_test.go
@@ -1,8 +1,60 @@
 package prompt
 
 import (
+	"bytes"
 	"testing"
 )
+
+func TestRemoveAllControlSequences(t *testing.T) {
+	f := NewFilter()
+	scenarioTable := []struct {
+		name     string
+		input    []byte
+		expected []byte
+	}{
+		{
+			name:     "case1",
+			input:    []byte{0x1b, 0x5b, 0x41},
+			expected: []byte{},
+		},
+		{
+			name:     "case2",
+			input:    []byte{0x5b, 0x1b, 0x5b, 0x41, 0x5b},
+			expected: []byte{0x5b, 0x5b},
+		},
+		{
+			name:     "case3",
+			input:    []byte{0x1b, 0x5b, 0x41, 0x1b, 0x5b, 0x41},
+			expected: []byte{},
+		},
+		{
+			name:     "case4",
+			input:    []byte{0x1b, 0x5b, 0x41, 0x5b, 0x1b, 0x5b, 0x41},
+			expected: []byte{0x5b},
+		},
+		{
+			name:     "case5",
+			input:    []byte{},
+			expected: []byte{},
+		},
+		{
+			name:     "case6",
+			input:    []byte{'a'},
+			expected: []byte{'a'},
+		},
+		{
+			name:     "case7",
+			input:    []byte{0x1b, 'a'},
+			expected: []byte{'a'},
+		},
+	}
+	for _, s := range scenarioTable {
+		ret := RemoveAllControlSequences(s.input, f)
+		if !bytes.Equal(ret, s.expected) {
+			t.Errorf("%s: Should be %#v, but got %#v", s.name, s.expected, ret)
+		}
+	}
+}
 
 func TestPosixParserGetKey(t *testing.T) {
 	scenarioTable := []struct {

--- a/internal/bisect/bisect_test.go
+++ b/internal/bisect/bisect_test.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/c-bata/go-prompt/internal/bisect"
+	"github.com/StepY1aoZz/go-prompt/internal/bisect"
 )
 
 func Example() {

--- a/internal/strings/strings_test.go
+++ b/internal/strings/strings_test.go
@@ -3,7 +3,7 @@ package strings_test
 import (
 	"fmt"
 
-	"github.com/c-bata/go-prompt/internal/strings"
+	"github.com/StepY1aoZz/go-prompt/internal/strings"
 )
 
 func ExampleIndexNotByte() {

--- a/option.go
+++ b/option.go
@@ -270,7 +270,6 @@ func OptionSetExitCheckerOnInput(fn ExitChecker) Option {
 func New(executor Executor, completer Completer, opts ...Option) *Prompt {
 	defaultWriter := NewStdoutWriter()
 	registerConsoleWriter(defaultWriter)
-
 	pt := &Prompt{
 		in: NewStandardInputParser(),
 		renderer: &Render{
@@ -297,6 +296,7 @@ func New(executor Executor, completer Completer, opts ...Option) *Prompt {
 		buf:         NewBuffer(),
 		executor:    executor,
 		history:     NewHistory(),
+		filter:      NewFilter(),
 		completion:  NewCompletionManager(completer, 6),
 		keyBindMode: EmacsKeyBind, // All the above assume that bash is running in the default Emacs setting
 	}

--- a/prompt.go
+++ b/prompt.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/c-bata/go-prompt/internal/debug"
+	"github.com/StepY1aoZz/go-prompt/internal/debug"
 )
 
 // Executor is called when user input something text.

--- a/prompt.go
+++ b/prompt.go
@@ -28,6 +28,7 @@ type Prompt struct {
 	renderer          *Render
 	executor          Executor
 	history           *History
+	filter            *BufferFilter
 	completion        *CompletionManager
 	keyBindings       []KeyBind
 	ASCIICodeBindings []ASCIICodeBind
@@ -154,6 +155,8 @@ func (p *Prompt) feed(b []byte) (shouldExit bool, exec *Exec) {
 		if p.handleASCIICodeBinding(b) {
 			return
 		}
+		// remove all control sequences before insert
+		b = RemoveAllControlSequences(b, p.filter)
 		p.buf.InsertText(string(b), false, true)
 	}
 

--- a/render.go
+++ b/render.go
@@ -3,7 +3,7 @@ package prompt
 import (
 	"runtime"
 
-	"github.com/c-bata/go-prompt/internal/debug"
+	"github.com/StepY1aoZz/go-prompt/internal/debug"
 	runewidth "github.com/mattn/go-runewidth"
 )
 

--- a/signal_posix.go
+++ b/signal_posix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package prompt
@@ -7,7 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/c-bata/go-prompt/internal/debug"
+	"github.com/StepY1aoZz/go-prompt/internal/debug"
 )
 
 func (p *Prompt) handleSignals(exitCh chan int, winSizeCh chan *WinSize, stop chan struct{}) {

--- a/signal_windows.go
+++ b/signal_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package prompt
@@ -7,7 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/c-bata/go-prompt/internal/debug"
+	"github.com/StepY1aoZz/go-prompt/internal/debug"
 )
 
 func (p *Prompt) handleSignals(exitCh chan int, winSizeCh chan *WinSize, stop chan struct{}) {


### PR DESCRIPTION
This PR fixed issues https://github.com/c-bata/go-prompt/issues/119, https://github.com/openGemini/openGemini/issues/519 and https://github.com/c-bata/go-prompt/issues/223.

When users input too fast (a common case  is scrolling mouse in tmux), more than one key code was read from STDIN. If there is any control key (i.e. UP,DOWN,DELETE) in it, they will be regarded as normal characters, and further output to the terminal. Also, the method calculating the length of current line returns a wrong value, which caused a part of current output cannot be erased.

This PR removed all control sequences in input before they were stored into buffer or output to the terminal.

### Example
![old-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/14c65740-3dae-47ae-9285-60b0996e1926)
**BEFORE**
![new-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/bad3f4d6-a1ff-48d5-a4ec-e3a58c0f71c8)
**AFTER**